### PR TITLE
verify module is not undefined and from type stylable for filtering

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -30,7 +30,7 @@ function processNode(node, replaceFn) {
 }
 
 function isImportedByNonStylable(module) {
-  return module.reasons.some(({ module }) => module.type !== "stylable");
+  return module.reasons.some(({ module }) => module && module.type !== "stylable");
 }
 
 function getCSSDepthAndDeps(module, cssDependencies = [], path = []) {
@@ -71,14 +71,12 @@ function getCSSDepthAndDeps(module, cssDependencies = [], path = []) {
   // Component depth
   if (reasons && isCSS) {
     const name = resource.replace(/\.st\.css$/, "");
-    
     const views = reasons
       .filter(({ module: _module }) => {
-        return _module.resource && _module.resource.indexOf(name) !== -1;
+        return _module && _module.type !== "stylable" && _module.resource && _module.resource.indexOf(name) !== -1;
       })
       .map(({ module }) => module);
-
-
+    
     if (new Set(views).size > 1) {
       throw new Error(`only one file with the name ${name} allowed`);
     }


### PR DESCRIPTION
When I used the plugin with `webpack@4` on an example project, it threw an error

<img width="1662" alt="screen shot 2018-03-21 at 16 40 18" src="https://user-images.githubusercontent.com/11733036/37716220-a550fefa-2d26-11e8-87da-6a655534445e.png">
<img width="1680" alt="screen shot 2018-03-21 at 16 39 39" src="https://user-images.githubusercontent.com/11733036/37716227-a9946470-2d26-11e8-87fd-16e6cd38bbeb.png">

**:confused: I'm not sure that this is the right solution :confused:**

There are some cases when the `module` variable does not exist.
There are some other cases when it does exist but it's not from type `stylable`.

This PR will make sure the plugin will ignore those cases.
