### PR TITLE
Move webpack from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "typescript": "^2.8.3",
     "url-regex": "^4.1.1",
     "webpack-dev-middleware": "^3.1.2",
-    "webpack-sources": "^1.1.0"
+    "webpack-sources": "^1.1.0",
+    "webpack": "^4.6.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
@@ -38,7 +39,6 @@
     "ts-loader": "^4.2.0",
     "ts-node": "^6.0.1",
     "url-loader": "^1.0.1",
-    "webpack": "^4.6.0",
     "webpack-cli": "^2.0.15"
   },
   "repository": {


### PR DESCRIPTION
I was trying to use `yoshi 2.1.x` with `wix-ui-core`.
I got an error :
```
{ Error: Cannot find module 'webpack/lib/GraphHelpers'
    at Function.Module._resolveFilename (module.js:536:15)
    at Function.Module._load (module.js:466:25)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/erezm/Projects/wix-ui/packages/wix-ui-core/node_modules/stylable-webpack-plugin/src/StylableModulesPlugin.js:3:35)
```

I found that the webpack version I have it version 3.x , which comes from the `wix-storybook-utils`.
(not 4.x which is what is needed for this plugin).

I have tried moving `webpack` to dependencies (in the `stylable-webpack-plugin`'s package.json), and running `npm i` in `wix-ui-core.

after that, running `npm run build` in `wix-ui-core` worked withot errors.
And I see using `npm ls webpack` that I have both version 3.x and version 4.x
